### PR TITLE
Invoke the actuator from the "core" program (and do so only once).

### DIFF
--- a/src/components/actuator.c
+++ b/src/components/actuator.c
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "actuate.h"
 #include "actuation_logic.h"
 #include "platform.h"
 

--- a/src/core.c
+++ b/src/core.c
@@ -91,7 +91,6 @@ int core_step(struct ui_values *ui) {
 
   // Actuate devices if necessary
   actuate_devices_generated_C();
-  actuate_devices_generated_C();
 
   int read_cmd = read_rts_command(&rts);
   if (read_cmd < 0) {
@@ -114,8 +113,6 @@ int core_step(struct ui_values *ui) {
   }
 
   err |= update_ui(ui);
-
-  // Self Test
 
   return err;
 }

--- a/src/include/actuate.h
+++ b/src/include/actuate.h
@@ -3,6 +3,12 @@
 
 // Combine the votes from both actuate logic components
 // and tell the hardware device to actuate (or unactuate)
+#include <stdint.h>
 int actuate_devices(void);
+
+// Return whether or not a device with the provided votes should be actuated
+// Bit i = vote by logic unit i
+// This function is generated directly from the Cryptol model
+uint8_t ActuateActuator(uint8_t vs);
 
 #endif // ACTUATE_H_


### PR DESCRIPTION
Remove redundant invocation of device actuation